### PR TITLE
style: Remove padding from code snippet

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -25,3 +25,7 @@
         height: 468px;
     }
 }
+
+.prose :where(pre):not(:where([class~="not-prose"] *)) {
+    padding: 0 !important;
+}


### PR DESCRIPTION
![スクリーンショット 2023-08-19 23 09 01](https://github.com/0machi/techblog/assets/113443658/1872cc60-75b7-4c2b-a6cc-1c7123553134)
コードスニペットの周りの枠線？みたいなものを消したかったので消しました。